### PR TITLE
Redhat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ A more complex example for CentOS is:
       - name: erlang
       - name: elixir
       - name: nodejs
-    asdf_plugin_dependencies:
+    asdf_optional_dependencies:
       # Erlang
       - gcc
       - glibc-devel

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure('2') do |config|
 
     machine.vm.provision 'ansible' do |ansible|
       ansible.playbook = 'tests/playbook.yml'
-      ansible.sudo = true
+      ansible.become = true
       ansible.inventory_path = 'tests/inventory'
       ansible.host_key_checking = false
     end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,31 @@
 ---
+# defaults file for asdf
+ansible_become: True
+
 asdf_plugins: []
-
-asdf_user: "deploy"
-
-asdf_legacy_version_file: "yes"
-
 # asdf_plugins:
 #   - name: "erlang"
 #     versions:
 #       - 18.3
 #       - 20.1
 #     global: 20.1
+
+asdf_user: "deploy"
+
+asdf_legacy_version_file: "yes"
+
+# Debian
+asdf_plugin_dependencies:
+  - automake
+  - autoconf
+  - build-essential
+  - libreadline-dev
+  - libncurses-dev
+  - libssl-dev
+  - libyaml-dev
+  - libxslt-dev
+  - libffi-dev
+  - libtool
+  - unzip
+
+apt_cache_valid_time: 86400

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for asdf
-ansible_become: True
+asdf_version: "v0.4.3"
 
 asdf_plugins: []
 # asdf_plugins:
@@ -14,18 +14,4 @@ asdf_user: "deploy"
 
 asdf_legacy_version_file: "yes"
 
-# Debian
-asdf_plugin_dependencies:
-  - automake
-  - autoconf
-  - build-essential
-  - libreadline-dev
-  - libncurses-dev
-  - libssl-dev
-  - libyaml-dev
-  - libxslt-dev
-  - libffi-dev
-  - libtool
-  - unzip
-
-apt_cache_valid_time: 86400
+asdf_optional_dependencies: []

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,7 +9,7 @@
   set_fact:
     "asdf_user_home": "{{ getent_passwd[asdf_user][4] }}"
 
-- name: "install global dependencies"
+- name: "install plugin dependencies with apt"
   apt:
     pkg: "{{ item }}"
     install_recommends: no
@@ -17,7 +17,7 @@
   with_items: "{{ asdf_plugin_dependencies }}"
   when: ansible_os_family == "Debian"
 
-- name: "install global dependencies"
+- name: "install plugin dependencies with yum"
   yum:
     name: "{{ item }}"
   with_items: "{{ asdf_plugin_dependencies }}"
@@ -27,7 +27,7 @@
   git:
     repo: "https://github.com/asdf-vm/asdf.git"
     dest: "{{ asdf_user_home }}/.asdf"
-    update: yes
+    version: "{{ asdf_version | default('HEAD') }}"
   become_user: "{{ asdf_user }}"
 
 - name: "source asdf script"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,9 @@
 ---
+- include_vars: "{{ item }}"
+  with_first_found:
+    - "../vars/{{ ansible_os_family }}.yml"
+    - "../vars/os_defaults.yml"
+
 - name: "get users HOME"
   getent:
     database: passwd
@@ -14,20 +19,24 @@
     pkg: "{{ item }}"
     install_recommends: no
     cache_valid_time: "{{ apt_cache_valid_time }}"
-  with_items: "{{ asdf_plugin_dependencies }}"
+  with_items:
+    - "{{ asdf_plugin_dependencies }}"
+    - "{{ asdf_optional_dependencies }}"
   when: ansible_os_family == "Debian"
 
 - name: "install plugin dependencies with yum"
   yum:
     name: "{{ item }}"
-  with_items: "{{ asdf_plugin_dependencies }}"
+  with_items:
+    - "{{ asdf_plugin_dependencies }}"
+    - "{{ asdf_optional_dependencies }}"
   when: ansible_os_family == "RedHat"
 
 - name: "install asdf"
   git:
     repo: "https://github.com/asdf-vm/asdf.git"
     dest: "{{ asdf_user_home }}/.asdf"
-    version: "{{ asdf_version | default('HEAD') }}"
+    version: "{{ asdf_version }}"
   become_user: "{{ asdf_user }}"
 
 - name: "source asdf script"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,6 +15,13 @@
     install_recommends: no
     cache_valid_time: "{{ apt_cache_valid_time }}"
   with_items: "{{ asdf_plugin_dependencies }}"
+  when: ansible_os_family == "Debian"
+
+- name: "install global dependencies"
+  yum:
+    name: "{{ item }}"
+  with_items: "{{ asdf_plugin_dependencies }}"
+  when: ansible_os_family == "RedHat"
 
 - name: "install asdf"
   git:

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,6 +1,8 @@
 ---
 - name: "install plugins"
   command: "bash -lc 'asdf plugin-add {{ item.name }}'"
+  args:
+    creates: "{{ asdf_user_home }}/.asdf/plugins/{{ item.name }}"
   with_items: "{{ asdf_plugins }}"
   when: asdf_plugins|length > 0
   become_user: "{{ asdf_user }}"
@@ -11,21 +13,23 @@
   with_subelements:
     - "{{ asdf_plugins }}"
     - versions
+    - flags:
+      skip_missing: True
   when: asdf_plugins|length > 0
   become_user: "{{ asdf_user }}"
 
 - name: "set global app versions"
   command: "bash -lc 'asdf global {{ item.name }} {{ item.global | default(item.versions[0]) }}'"
+  when: item.versions is defined
   with_items: "{{ asdf_plugins }}"
-  when: asdf_plugins|length > 0
   become_user: "{{ asdf_user }}"
 
-- name: "set default version"
-  command: "bash -lc 'asdf install'"
-  args:
-    chdir: "{{ asdf_user_home }}"
-  when: asdf_plugins|length > 0
-  become_user: "{{ asdf_user }}"
+# - name: "set default version"
+#   command: "bash -lc 'asdf install'"
+#   args:
+#     chdir: "{{ asdf_user_home }}"
+#   when: asdf_plugins|length > 0
+#   become_user: "{{ asdf_user }}"
 
 - name: "set asdfrc"
   template:

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -10,6 +10,8 @@
 
 - name: "install apps"
   command: "bash -lc 'asdf install {{ item.0.name }} {{ item.1 }}'"
+  args:
+    creates: "{{ asdf_user_home }}/.asdf/installs/{{ item.0.name }}/{{ item.1 }}"
   with_subelements:
     - "{{ asdf_plugins }}"
     - versions
@@ -23,13 +25,6 @@
   when: item.versions is defined
   with_items: "{{ asdf_plugins }}"
   become_user: "{{ asdf_user }}"
-
-# - name: "set default version"
-#   command: "bash -lc 'asdf install'"
-#   args:
-#     chdir: "{{ asdf_user_home }}"
-#   when: asdf_plugins|length > 0
-#   become_user: "{{ asdf_user }}"
 
 - name: "set asdfrc"
   template:

--- a/templates/asdf.sh.j2
+++ b/templates/asdf.sh.j2
@@ -1,6 +1,7 @@
 # {{ ansible_managed }}
 
+[ -n "$BASH_VERSION" ] || return 0
+
 if [ -f "$HOME/.asdf/asdf.sh" ]; then
   source "$HOME/.asdf/asdf.sh"
 fi
-

--- a/tests/Dockerfile-centos7
+++ b/tests/Dockerfile-centos7
@@ -1,0 +1,18 @@
+FROM centos:7
+
+RUN yum -y install epel-release && \
+    yum -y install sudo python python-devel python-pip gcc make \
+     initscripts libffi-devel openssl-devel && \
+    pip install -q cffi && \
+    pip install -q ansible==2.5.1
+
+WORKDIR /tmp/ansible-role-asdf
+COPY  .  /tmp/ansible-role-asdf
+
+RUN useradd -m vagrant
+RUN echo localhost > inventory
+
+RUN ansible-playbook -i inventory -c local tests/playbook.yml
+
+RUN sudo -iu vagrant bash -lc 'asdf --version'
+RUN sudo -iu vagrant bash -lc 'elixir --version'

--- a/tests/Dockerfile-ubuntu16.04
+++ b/tests/Dockerfile-ubuntu16.04
@@ -1,0 +1,18 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -qq && \
+    apt-get install -qq sudo python-apt python-pycurl python-pip python-dev \
+                        libffi-dev libssl-dev && \
+    pip install -U setuptools && \
+    pip install -q ansible==2.5.1
+
+WORKDIR /tmp/ansible-role-asdf
+COPY  .  /tmp/ansible-role-asdf
+
+RUN useradd -m vagrant
+RUN echo localhost > inventory
+
+RUN ansible-playbook -i inventory -c local tests/playbook.yml
+
+RUN sudo -iu vagrant bash -lc 'asdf --version'
+RUN sudo -iu vagrant bash -lc 'elixir --version'

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -5,7 +5,7 @@
       asdf_user: vagrant
       asdf_plugins:
         - name: "erlang"
-          versions: ["18.3", "20.1"]
+          versions: ["20.1"]
           global: "20.1"
         - name: "elixir"
-          versions: ["1.5.1", "1.4.1", "1.3.3"]
+          versions: ["1.5.1", "1.4.1"]

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,14 @@
+asdf_plugin_dependencies:
+  - automake
+  - autoconf
+  - build-essential
+  - libreadline-dev
+  - libncurses-dev
+  - libssl-dev
+  - libyaml-dev
+  - libxslt-dev
+  - libffi-dev
+  - libtool
+  - unzip
+  - git
+  - curl

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,13 @@
+asdf_plugin_dependencies:
+  - automake
+  - autoconf
+  - readline-devel
+  - ncurses-devel
+  - openssl-devel
+  - libyaml-devel
+  - libxslt-devel
+  - libffi-devel
+  - libtool
+  - unzip
+  - git
+  - curl

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,5 @@
 ---
 # vars file for asdf
+ansible_become: True
+
+apt_cache_valid_time: 86400

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,17 +1,2 @@
 ---
-ansible_become: True
-apt_cache_valid_time: 86400
-
-asdf_plugin_dependencies:
-  - automake
-  - autoconf
-  - build-essential
-  - libreadline-dev
-  - libncurses-dev
-  - libssl-dev
-  - libyaml-dev
-  - libxslt-dev
-  - libffi-dev
-  - libtool
-  - unzip
-
+# vars file for asdf

--- a/vars/os_defaults.yml
+++ b/vars/os_defaults.yml
@@ -1,0 +1,1 @@
+asdf_plugin_dependencies: []


### PR DESCRIPTION
This PR adds support for RedHat derived distros. That required moving variables from `vars/main.yml` to `defaults/main.yml` so they can be overridden in a playbook. 

It also allows the version of asdf to be set with a new `asdf_version` variable, rather than floating with the latest git trunk. 

It also allows versions to be undefined on the initial installation of asdf. We normally handle builds by running `asdf install` in the source checkout, with the versions controlled by e.g. `~/build/foo/.tool-versions` 