### PR TITLE
Import nodejs keyring before install app if plugin list contains nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ A more complex example for CentOS is:
       - name: erlang
       - name: elixir
       - name: nodejs
+        versions: ["8.11.3"]
+        global: "8.11.3"
     asdf_optional_dependencies:
       # Erlang
       - gcc
@@ -98,21 +100,6 @@ A more complex example for CentOS is:
       - perl-Digest-SHA
   roles:
     - asdf
-  tasks:
-    - name: Set vars
-      set_fact:
-        asdf_nodejs_keyring: "{{ asdf_user_home }}/.asdf/keyrings/nodejs"
-
-    - name: create keyring for Node.js keys
-      file: path={{ asdf_nodejs_keyring }} state=directory owner={{ asdf_user }} {{ asdf_user }} mode=0700
-
-    - name: import Node.js keys to keyring
-      command: "bash -lc '{{ asdf_user_home }}/.asdf/plugins/nodejs/bin/import-release-team-keyring'"
-      args:
-        creates: "{{ asdf_nodejs_keyring }}/pubring.gpg"
-      become_user: "{{ asdf_user }}"
-      environment:
-        GNUPGHOME: "{{ asdf_nodejs_keyring }}"
 ```
 
 ## License

--- a/tasks/import-nodejs-keyring.yml
+++ b/tasks/import-nodejs-keyring.yml
@@ -1,0 +1,15 @@
+---
+- name: Set vars
+  set_fact:
+    asdf_nodejs_keyring: "{{ asdf_user_home }}/.asdf/keyrings/nodejs"
+
+- name: Create keyring for Node.js keys
+  file: path={{ asdf_nodejs_keyring }} state=directory owner={{ asdf_user }} group={{ asdf_user }} mode=0700
+
+- name: Import Node.js keys to keyring
+  command: "bash -lc '{{ asdf_user_home }}/.asdf/plugins/nodejs/bin/import-release-team-keyring'"
+  args:
+    creates: "{{ asdf_nodejs_keyring }}/pubring.gpg"
+  become_user: "{{ asdf_user }}"
+  environment:
+    GNUPGHOME: "{{ asdf_nodejs_keyring }}"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -8,6 +8,13 @@
   become_user: "{{ asdf_user }}"
   ignore_errors: True
 
+- name: "set vars"
+  set_fact:
+    has_nodejs_plugin: ("nodejs" in "{{ asdf_plugins }}")
+
+- include_tasks: tasks/import-nodejs-keyring.yml
+  when: has_nodejs_plugin
+
 - name: "install apps"
   command: "bash -lc 'asdf install {{ item.0.name }} {{ item.1 }}'"
   args:


### PR DESCRIPTION
To install Nodejs via asdf in one step, we need to import Nodejs keyring before installing Nodejs apps. We can execute the keyring import command if Nodejs is in the plugin list.