### PR TITLE
Add support for shared installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ The variable `asdf_user` sets a user for which the role is installed:
 asdf_user: "deploy"
 ```
 
+By default the role installs `asdf` and its plugins in the `~/.asdf` for this
+user. This behaviour can be changed by setting `asdf_dir`. This is useful in
+situations where multiple users need access to installed plugins and tools (e.g.
+a deploy user, the app user, and possibly developer users).
+
+```yaml
+asdf_dir: "/opt/asdf-vm"
+```
+
 The variable `asdf_legacy_version_file` specifies if plugins which support this feature should read the version files used by other version managers (e.g. `.ruby-version` in the case of Ruby's rbenv).
 
 ```yaml
@@ -49,7 +58,7 @@ asdf_plugin_dependencies: []
 The variable `asdf_version` sets the git tag of asdf:
 
 ```yaml
-asdf_version: v0.6.2
+asdf_version: v0.9.0
 ```
 
 ## Dependencies
@@ -81,6 +90,26 @@ A more complex example for CentOS is:
   vars:
     asdf_version: v0.6.2
     asdf_user: ci
+    asdf_plugins:
+      - name: erlang
+      - name: elixir
+      - name: nodejs
+        versions: ["8.11.3"]
+        global: "8.11.3"
+  roles:
+    - asdf
+```
+
+Installing asdf into a shared directory accessible to the `developers` group:
+
+```yaml
+- name: install asdf
+  hosts: '*'
+  become: true
+  vars:
+    asdf_user: deploy
+    asdf_group: developers
+    asdf_dir: /opt/asdf-vm
     asdf_plugins:
       - name: erlang
       - name: elixir

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 # defaults file for asdf
 asdf_version: "v0.8.1"
 asdf_user: "deploy"
+asdf_group: "deploy"
+# defaults to ~/.asdf for the specified user
+#asdf_dir: "/opt/asdf-vm"
 asdf_legacy_version_file: "yes"
 
 asdf_plugins: []

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,10 +4,32 @@
     database: passwd
     key: "{{ asdf_user }}"
     split: ":"
+  when: asdf_dir is undefined
 
-- name: "set asdf_user_home variable"
+- name: "set asdf_config_file based on home directory"
   set_fact:
-    "asdf_user_home": "{{ getent_passwd[asdf_user][4] }}"
+    asdf_config_file: "{{ getent_passwd[asdf_user][4] }}/.asdfrc"
+  when: asdf_dir is undefined and asdf_config_file is undefined
+
+- name: "set asdf_default_tool_versions_file based on home directory"
+  set_fact:
+    asdf_default_tool_versions_file: "{{ getent_passwd[asdf_user][4] }}/.tool-versions"
+  when: asdf_dir is undefined and asdf_default_tool_versions_file is undefined
+
+- name: "set asdf_dir variable based on home directory"
+  set_fact:
+    asdf_dir: "{{ getent_passwd[asdf_user][4] }}/.asdf"
+  when: asdf_dir is undefined
+
+- name: "set asdf_config_file variable based on asdf_dir"
+  set_fact:
+    asdf_config_file: "{{ asdf_dir }}/asdfrc"
+  when: asdf_config_file is undefined
+
+- name: "set asdf_default_tool_versions_file variable based on asdf_dir"
+  set_fact:
+    asdf_default_tool_versions_file: "{{ asdf_dir }}/tool-versions"
+  when: asdf_default_tool_versions_file is undefined
 
 - name: "install asdf global dependencies with apt"
   apt:
@@ -29,10 +51,18 @@
   until: yum_deps_result is succeeded
   when: ansible_os_family == "RedHat"
 
+- name: "ensure asdf_dir presence and ownership"
+  file:
+    path: "{{ asdf_dir }}"
+    owner: "{{ asdf_user }}"
+    group: "{{ asdf_group }}"
+    state: directory
+  become: True
+
 - name: "install asdf"
   git:
     repo: "https://github.com/asdf-vm/asdf.git"
-    dest: "{{ asdf_user_home }}/.asdf"
+    dest: "{{ asdf_dir }}"
     version: "{{ asdf_version }}"
   become: True
   become_user: "{{ asdf_user }}"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -20,12 +20,11 @@
   when: ansible_os_family == "RedHat"
 
 - name: "install plugins"
-  command: "bash -lc 'asdf plugin-add {{ item.name }} {{ item.repository | default() }}'"
+  command: "bash -lc 'source /etc/profile.d/asdf.sh && asdf plugin-add {{ item.name }} {{ item.repository | default() }}'"
   args:
-    creates: "{{ asdf_user_home }}/.asdf/plugins/{{ item.name }}"
-    chdir: "{{ asdf_user_home }}"
+    creates: "{{ asdf_dir }}/plugins/{{ item.name }}"
   with_items: "{{ asdf_plugins }}"
-  when: asdf_plugins|length > 0
+  when: asdf_plugins | length > 0
   become: True
   become_user: "{{ asdf_user }}"
   ignore_errors: True
@@ -51,37 +50,33 @@
   with_items: "{{ asdf_plugins }}"
 
 - name: "install apps"
-  command: "bash -lc 'asdf install {{ item.0.name }} {{ item.1 }}'"
+  command: "bash -lc 'source /etc/profile.d/asdf.sh && asdf install {{ item.0.name }} {{ item.1 }}'"
   args:
-    creates: "{{ asdf_user_home }}/.asdf/installs/{{ item.0.name }}/{{ item.1 }}"
-    chdir: "{{ asdf_user_home }}"
+    creates: "{{ asdf_dir }}/installs/{{ item.0.name }}/{{ item.1 }}"
   with_subelements:
     - "{{ asdf_plugins }}"
     - versions
     - flags:
       skip_missing: True
-  when: asdf_plugins|length > 0
+  when: asdf_plugins | length > 0
   become: True
   become_user: "{{ asdf_user }}"
 
 - name: "uninstall apps"
-  command: "bash -lc 'asdf uninstall {{ item.0.name }} {{ item.1 }}'"
+  command: "bash -lc 'source /etc/profile.d/asdf.sh && asdf uninstall {{ item.0.name }} {{ item.1 }}'"
   args:
-    removes: "{{ asdf_user_home }}/.asdf/installs/{{ item.0.name }}/{{ item.1 }}"
-    chdir: "{{ asdf_user_home }}"
+    removes: "{{ asdf_dir }}/installs/{{ item.0.name }}/{{ item.1 }}"
   with_subelements:
     - "{{ asdf_plugins }}"
     - delete_versions
     - flags:
       skip_missing: True
-  when: asdf_plugins|length > 0
+  when: asdf_plugins | length > 0
   become: True
   become_user: "{{ asdf_user }}"
 
 - name: "set global app versions"
-  command: "bash -lc 'asdf global {{ item.name }} {{ item.global | default(item.versions | difference(item.delete_versions|default([])) | sort | first) }}'"
-  args:
-    chdir: "{{ asdf_user_home }}"
+  command: "bash -lc 'source /etc/profile.d/asdf.sh && asdf global {{ item.name }} {{ item.global | default(item.versions | difference(item.delete_versions|default([])) | sort | first) }}'"
   when: item.versions is defined
   with_items: "{{ asdf_plugins }}"
   become: True
@@ -90,8 +85,18 @@
 - name: "set asdfrc"
   template:
     src: "asdfrc.j2"
-    dest: "{{ asdf_user_home }}/.asdfrc"
+    dest: "{{ asdf_config_file }}"
     owner: "{{ asdf_user }}"
+    group: "{{ asdf_group }}"
     mode: 0644
   become: True
   become_user: "{{ asdf_user }}"
+
+- name: "set group permissions"
+  become: yes
+  file:
+    path: "{{ asdf_dir }}"
+    owner: "{{ asdf_user }}"
+    group: "{{ asdf_group }}"
+    state: directory
+    recurse: yes

--- a/tasks/plugins/nodejs.yml
+++ b/tasks/plugins/nodejs.yml
@@ -21,11 +21,11 @@
 
 - name: "set vars"
   set_fact:
-    asdf_nodejs_keyring: "{{ asdf_user_home }}/.asdf/keyrings/nodejs"
+    asdf_nodejs_keyring: "{{ asdf_dir }}/keyrings/nodejs"
 
 - name: Check if Node.js keys need to be imported
   stat:
-    path: "{{ asdf_user_home }}/.asdf/plugins/nodejs/bin/import-release-team-keyring"
+    path: "{{ asdf_dir }}/plugins/nodejs/bin/import-release-team-keyring"
   register: import_keyring_binary
 
 - name: "create keyring for Node.js keys"
@@ -33,14 +33,14 @@
     path: "{{ asdf_nodejs_keyring }}"
     state: directory
     owner: "{{ asdf_user }}"
-    group: "{{ asdf_user }}"
+    group: "{{ asdf_group }}"
     mode: 0700
   become: True
   become_user: "{{ asdf_user }}"
   when: import_keyring_binary.stat.exists
 
 - name: "import Node.js keys to keyring"
-  command: "bash -lc '{{ asdf_user_home }}/.asdf/plugins/nodejs/bin/import-release-team-keyring'"
+  command: "bash -lc '{{ asdf_dir }}/plugins/nodejs/bin/import-release-team-keyring'"
   args:
     creates: "{{ asdf_nodejs_keyring }}/pubring.gpg"
   environment:

--- a/templates/asdf.sh.j2
+++ b/templates/asdf.sh.j2
@@ -2,6 +2,11 @@
 
 [ -n "$BASH_VERSION" ] || return 0
 
-if [ -f "$HOME/.asdf/asdf.sh" ]; then
-  source "$HOME/.asdf/asdf.sh"
+export ASDF_CONFIG_FILE="{{ asdf_config_file }}"
+export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="{{ asdf_default_tool_versions_file }}"
+export ASDF_DIR="{{ asdf_dir }}"
+export ASDF_DATA_DIR="{{ asdf_dir }}"
+
+if [ -f "$ASDF_DIR/asdf.sh" ]; then
+  source "$ASDF_DIR/asdf.sh"
 fi


### PR DESCRIPTION
This change allows installation to a shared directory that could be made accessible to multiple users who share the same group.

It changes global `asdf` configuration via environment variables in `/etc/profile.d/asdf.sh` to point to this shared directory. This includes globally set default `tool-versions` file which could still be overridden in a users home directory or at project level if necessary.

Installing to the user's home directory with asdf's defaults has been kept as default behaviour.