### PR TITLE
Adds python to ansible-role-asdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ asdf_plugins:
     versions:         # a list of versions to install
       - 18.3
       - 20.1
+    env: "CC=clang"   # environment variables to be set for the installation, optional
     global: 20.1      # set as a global version, optional
 ```
 
@@ -79,6 +80,19 @@ Playbook example is given below:
       global: "20.1"
     - name: "elixir"
       versions: "1.3.1"
+```
+
+Providing environment variables to the install:
+
+```yaml
+- hosts: web
+  roles:
+  - role: ansible-role-asdf
+    asdf_plugins:
+    - name: "python"
+      versions: ["3.6.8", "3.10.8"]
+      env: "CC=clang"
+      global: "3.6.8"
 ```
 
 A more complex example for CentOS is:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,8 @@ asdf_yum_php_dependencies: ["re2c", "gettext", "libxml2-devel", "bzip2-devel", "
 
 asdf_apt_ruby_dependencies: ["libssl-dev", "libyaml-dev", "zlib1g-dev", "libncurses5-dev", "libffi-dev"]
 asdf_yum_ruby_dependencies: ["openssl-devel", "libyaml-devel", "zlib-devel", "ncurses-devel", "libffi-devel", "bzip2"]
+
+asdf_apt_python_dependencies: ["clang", "build-essential",  "libssl-dev", "zlib1g-dev", "libbz2-dev", "libsqlite3-dev", "wget", "llvm", 
+  "libncursesw5-dev", "xz-utils", "tk-dev", "libxml2-dev", "libxmlsec1-dev", "libffi-dev", "liblzma-dev"]
+asdf_yum_python_dependencies: ["clang", "zlib-devel", "bzip2", "bzip2-devel", "sqlite", "sqlite-devel", "openssl-devel", "tk-devel", 
+  "libffi-devel", "xz-devel"]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,5 +24,6 @@ galaxy_info:
     - erlang
     - elixir
     - ruby
+    - python
 
 dependencies: []

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -49,8 +49,13 @@
   when: '"php" in item["name"]'
   with_items: "{{ asdf_plugins }}"
 
+- name: "python specific tasks"
+  include_tasks: "plugins/python.yml"
+  when: '"python" in item["name"]'
+  with_items: "{{ asdf_plugins }}"
+
 - name: "install apps"
-  command: "bash -lc 'source /etc/profile.d/asdf.sh && asdf install {{ item.0.name }} {{ item.1 }}'"
+  command: "bash -lc 'source /etc/profile.d/asdf.sh && {{ item.0.env | default() }} asdf install {{ item.0.name }} {{ item.1 }}'"
   args:
     creates: "{{ asdf_dir }}/installs/{{ item.0.name }}/{{ item.1 }}"
   with_subelements:

--- a/tasks/plugins/python.yml
+++ b/tasks/plugins/python.yml
@@ -1,0 +1,20 @@
+---
+- name: "install python dependencies with apt"
+  apt:
+    name: "{{ asdf_apt_python_dependencies }}"
+    install_recommends: no
+    cache_valid_time: "{{ apt_cache_valid_time }}"
+  retries: "{{ remote_package_retries }}"
+  register: apt_python_result
+  until: apt_python_result is succeeded
+  become: True
+  when: ansible_os_family == "Debian"
+
+- name: "install python dependencies with yum"
+  yum:
+    name: "{{ asdf_yum_python_dependencies }}"
+  retries: "{{ remote_package_retries }}"
+  register: yum_python_result
+  until: yum_python_result is succeeded
+  become: True
+  when: ansible_os_family == "RedHat"

--- a/tests/python.yml
+++ b/tests/python.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  roles:
+    - role: ansible-role-asdf
+      asdf_plugins:
+        - name: "python"
+          versions: ["3.6.8"]
+          env: "CC=clang"


### PR DESCRIPTION
* Allow additional environment variables to be passed for `asdf install` (e.g. `CC=clang`) This helps the fix some installation issues that can occur.
* Add the installation of python build dependencies for apt and yum systems.
  From: https://github.com/pyenv/pyenv/wiki\#suggested-build-environment