### PR TITLE
Added installing build dependencies for Arch Linux

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,20 +18,29 @@ asdf_apt_global_dependencies: ["unzip", "git", "curl", "autoconf", "automake", "
   "g++", "make", "patch", "pkg-config", "binutils", "libtool", "bison", "libreadline-dev"]
 asdf_yum_global_dependencies: ["unzip", "git", "curl", "autoconf", "automake", "gcc",
   "gcc-c++", "make", "patch", "pkgconfig", "binutils", "libtool", "bison", "readline-devel"]
+asdf_pacman_global_dependencies: ["unzip", "git", "curl", "autoconf", "automake", "gcc",
+  "make", "patch", "pkgconf", "binutils", "libtool", "bison", "readline"]
 
 asdf_apt_optional_dependencies: []
 asdf_yum_optional_dependencies: []
+asdf_pacman_optional_dependencies: []
 
 asdf_apt_erlang_dependencies: ["fop", "gettext", "xsltproc", "libncurses5-dev", "libssl-dev", "libxslt-dev", "libyaml-dev", "zlib1g-dev"]
 asdf_yum_erlang_dependencies: ["fop", "gettext", "libxslt", "ncurses-devel", "openssl-devel", "libxslt-devel", "libyaml-devel", "zlib-devel"]
+asdf_pacman_erlang_dependencies: ["fop", "gettext", "libxslt", "ncurses", "openssl", "libyaml", "zlib"]
+
 
 asdf_apt_nodejs_dependencies: ["gpg", "dirmngr"]
 asdf_yum_nodejs_dependencies: ["gpg", "perl-Digest-SHA"]
+asdf_pacman_nodejs_dependencies: ["gpgme", "perl-digest-sha1"]
 
 asdf_apt_php_dependencies: ["re2c", "gettext", "libxml2-dev", "libbz2-dev", "libcurl4-openssl-dev", "zlib1g-dev",
   "libicu-dev", "libjpeg-dev", "libpng-dev", "libwebp-dev", "libedit-dev", "libssl-dev", "libfreetype6-dev"]
 asdf_yum_php_dependencies: ["re2c", "gettext", "libxml2-devel", "bzip2-devel", "libcurl-devel", "zlib-devel",
   "libicu-devel", "libjpeg-devel", "libpng-devel", "libwebp-devel", "libedit-devel", "openssl-devel", "libfreetype6-devel"]
+asdf_pacman_php_dependencies: ["re2c", "gettext", "libxml2", "bzip2", "zlib",
+  "icu", "libjpeg-turbo", "libpng", "libwebp", "libedit", "openssl", "freetype2"]
 
 asdf_apt_ruby_dependencies: ["libssl-dev", "libyaml-dev", "zlib1g-dev", "libncurses5-dev", "libffi-dev"]
 asdf_yum_ruby_dependencies: ["openssl-devel", "libyaml-devel", "zlib-devel", "ncurses-devel", "libffi-devel", "bzip2"]
+asdf_pacman_ruby_dependencies: ["openssl", "libyaml", "zlib", "ncurses", "libffi", "bzip2"]

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -31,7 +31,7 @@
 
 - name: "install asdf global dependencies with pacman"
   pacman:
-    name: "{{ asdf_pacman_gloabal_dependencies }}"
+    name: "{{ asdf_pacman_global_dependencies }}"
     state: present
   become: True
   retries: "{{ remote_package_retries }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,6 +29,16 @@
   until: yum_deps_result is succeeded
   when: ansible_os_family == "RedHat"
 
+- name: "install asdf global dependencies with pacman"
+  pacman:
+    name: "{{ asdf_pacman_gloabal_dependencies }}"
+    state: present
+  become: True
+  retries: "{{ remote_package_retries }}"
+  register: pacman_deps_result
+  until: pacamn_deps_result is succeeded
+  when: ansible_os_family == "Archlinux"
+
 - name: "install asdf"
   git:
     repo: "https://github.com/asdf-vm/asdf.git"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -36,7 +36,7 @@
   become: True
   retries: "{{ remote_package_retries }}"
   register: pacman_deps_result
-  until: pacamn_deps_result is succeeded
+  until: pacman_deps_result is succeeded
   when: ansible_os_family == "Archlinux"
 
 - name: "install asdf"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -19,6 +19,16 @@
   become: True
   when: ansible_os_family == "RedHat"
 
+- name: "install plugin dependencies with pacman"
+  pacman:
+    name: "{{ asdf_pacman_optional_dependencies }}"
+    state: present
+  retries: "{{ remote_package_retries }}"
+  register: pacman_result
+  until: pacman_result is succeeded
+  become: True
+  when: ansible_os_family == "Archlinux"
+
 - name: "install plugins"
   command: "bash -lc 'asdf plugin-add {{ item.name }} {{ item.repository | default() }}'"
   args:

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -27,7 +27,7 @@
   register: pacman_result
   until: pacman_result is succeeded
   become: True
-  when: ansible_os_family == "Archlinux"
+  when: ansible_os_family == "Archlinux" and asdf_pacman_optional_dependencies > 0
 
 - name: "install plugins"
   command: "bash -lc 'asdf plugin-add {{ item.name }} {{ item.repository | default() }}'"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -27,7 +27,7 @@
   register: pacman_result
   until: pacman_result is succeeded
   become: True
-  when: ansible_os_family == "Archlinux" and asdf_pacman_optional_dependencies > 0
+  when: ansible_os_family == "Archlinux" and asdf_pacman_optional_dependencies|length > 0
 
 - name: "install plugins"
   command: "bash -lc 'asdf plugin-add {{ item.name }} {{ item.repository | default() }}'"

--- a/tasks/plugins/erlang.yml
+++ b/tasks/plugins/erlang.yml
@@ -18,3 +18,13 @@
   until: yum_erlang_result is succeeded
   become: True
   when: ansible_os_family == "RedHat"
+
+- name: "install erlang dependencies with pacman"
+  pacman:
+    name: "{{ asdf_pacman_erlang_dependencies }}"
+    state: present
+  retries: "{{ remote_package_retries }}"
+  register: pacman_erlang_result
+  until: pacman_erlang_result is succeeded
+  become: True
+  when: ansible_os_family == "Archlinux"

--- a/tasks/plugins/nodejs.yml
+++ b/tasks/plugins/nodejs.yml
@@ -19,6 +19,16 @@
   become: True
   when: ansible_os_family == "RedHat"
 
+- name: "install nodejs dependencies with pacman"
+  pacman:
+    name: "{{ asdf_pacman_nodejs_dependencies }}"
+    state: present
+  retries: "{{ remote_package_retries }}"
+  register: pacman_nodejs_result
+  until: pacman_nodejs_result is succeeded
+  become: True
+  when: ansible_os_family == "Archlinux"
+
 - name: "set vars"
   set_fact:
     asdf_nodejs_keyring: "{{ asdf_user_home }}/.asdf/keyrings/nodejs"

--- a/tasks/plugins/nodejs.yml
+++ b/tasks/plugins/nodejs.yml
@@ -28,33 +28,3 @@
   until: pacman_nodejs_result is succeeded
   become: True
   when: ansible_os_family == "Archlinux"
-
-- name: "set vars"
-  set_fact:
-    asdf_nodejs_keyring: "{{ asdf_user_home }}/.asdf/keyrings/nodejs"
-
-- name: Check if Node.js keys need to be imported
-  stat:
-    path: "{{ asdf_user_home }}/.asdf/plugins/nodejs/bin/import-release-team-keyring"
-  register: import_keyring_binary
-
-- name: "create keyring for Node.js keys"
-  file:
-    path: "{{ asdf_nodejs_keyring }}"
-    state: directory
-    owner: "{{ asdf_user }}"
-    group: "{{ asdf_user }}"
-    mode: 0700
-  become: True
-  become_user: "{{ asdf_user }}"
-  when: import_keyring_binary.stat.exists
-
-- name: "import Node.js keys to keyring"
-  command: "bash -lc '{{ asdf_user_home }}/.asdf/plugins/nodejs/bin/import-release-team-keyring'"
-  args:
-    creates: "{{ asdf_nodejs_keyring }}/pubring.gpg"
-  environment:
-    GNUPGHOME: "{{ asdf_nodejs_keyring }}"
-  become: True
-  become_user: "{{ asdf_user }}"
-  when: import_keyring_binary.stat.exists

--- a/tasks/plugins/php.yml
+++ b/tasks/plugins/php.yml
@@ -18,3 +18,13 @@
   until: yum_php_result is succeeded
   become: True
   when: ansible_os_family == "RedHat"
+
+- name: "install php dependencies with pacman"
+  pacman:
+    name: "{{ asdf_pacman_php_dependencies }}"
+    state: present
+  retries: "{{ remote_package_retries }}"
+  register: pacman_php_result
+  until: pacman_php_result is succeeded
+  become: True
+  when: ansible_os_family == "Archlinux"

--- a/tasks/plugins/ruby.yml
+++ b/tasks/plugins/ruby.yml
@@ -18,3 +18,13 @@
   until: yum_ruby_result is succeeded
   become: True
   when: ansible_os_family == "RedHat"
+
+- name: "install ruby dependencies with pacman"
+  pacman:
+    name: "{{ asdf_pacman_ruby_dependencies }}"
+    state: present
+  retries: "{{ remote_package_retries }}"
+  register: pacman_ruby_result
+  until: pacman_ruby_result is succeeded
+  become: True
+  when: ansible_os_family == "Archlinux"


### PR DESCRIPTION
To use this role on Arch Linux-based computers,  more functions must be added to install the required dependencies using Pacman, the Arch Linux package manager.